### PR TITLE
remove circular reference to static directory

### DIFF
--- a/server/horizon/settings.py
+++ b/server/horizon/settings.py
@@ -187,8 +187,7 @@ REACT_APP_DIR = os.path.join('client')
 if not DEBUG:
     STATICFILES_DIRS = [
         os.path.join(REACT_APP_DIR, 'build', 'static'),
-        os.path.join(REACT_APP_DIR, 'build'),
-        os.path.join('static')
+        os.path.join(REACT_APP_DIR, 'build')
     ]
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 


### PR DESCRIPTION
@pierreuno I'm going to go ahead and just merge this to unblock deployment of #12, but feel free to comment or do a subsequent PR if you think this isn't the correct fix. 

The issue encountered is that collectstatic failed when deploying to heroku, based on the addition of static to the `STATICFILES_DIRS`. I did some local testing, and it looked like that was causing a circular reference as coded. Heroku suggests a slightly different configuration [here](https://devcenter.heroku.com/articles/django-assets) that might work, but I'm not sure it's needed in the non-debug block where it was. If we need it for the debugging tools, let's add it to the debug block? If I'm missing another reason we needed that, just let me know.